### PR TITLE
Add optional parameters support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,11 @@ Vulnerable app target: OWASP Juice Shop (running at http://localhost:3000)
 - /reports: Output of scans
 - /patches: Fix diffs for vulnerable apps
 
-## Run tests:
+## Run tests
+
+Execute all testcases using the helper script. Optional arguments like the target
+`--base-url` can be provided and will be forwarded to the Python runner:
+
+```bash
+./run_tests.sh --base-url http://localhost:3000
+```

--- a/run_testcases.py
+++ b/run_testcases.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import argparse
 
 TEST_DIR = os.path.join(os.path.dirname(__file__), 'testcases')
 
@@ -12,12 +13,17 @@ def discover_tests(directory):
                 yield os.path.join(root, fname)
 
 
-def run_test(test_file):
-    result = subprocess.run([sys.executable, test_file])
+def run_test(test_file, base_url):
+    result = subprocess.run([sys.executable, test_file, "--base-url", base_url])
     return result.returncode
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Run all security testcases")
+    parser.add_argument("--base-url", default="http://localhost:3000",
+                        help="Base URL for the target application")
+    args = parser.parse_args()
+
     if not os.path.isdir(TEST_DIR):
         print(f'No testcases directory found at {TEST_DIR}')
         sys.exit(1)
@@ -29,7 +35,7 @@ def main():
     failures = 0
     for test in tests:
         print(f'Running {test}...')
-        code = run_test(test)
+        code = run_test(test, args.base_url)
         if code != 0:
             print(f'Failed: {test}')
             failures += 1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Run all testcases with optional parameters
+# Usage: ./run_tests.sh [options]
+# Options are passed to run_testcases.py
+
+python run_testcases.py "$@"

--- a/testcases/test_sql_injection.py
+++ b/testcases/test_sql_injection.py
@@ -1,4 +1,6 @@
 import requests
+import argparse
+import sys
 
 
 def test_sql_injection(base_url):
@@ -8,3 +10,22 @@ def test_sql_injection(base_url):
     if r.status_code == 200 and "error" not in r.text.lower():
         return {"vulnerable": True, "payload": payload}
     return {"vulnerable": False}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SQL injection test")
+    parser.add_argument("--base-url", default="http://localhost:3000",
+                        help="Base URL of the target application")
+    args = parser.parse_args()
+
+    result = test_sql_injection(args.base_url)
+    if result["vulnerable"]:
+        print("SQL Injection vulnerability detected with payload:", result["payload"])
+        sys.exit(1)
+    else:
+        print("No SQL Injection vulnerability detected.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add run_tests.sh wrapper for all testcases
- allow passing `--base-url` to `run_testcases.py`
- make SQL injection testcase runnable as a script
- document optional parameters in README

## Testing
- `pip install -r requirements.txt`
- `./run_tests.sh --base-url http://localhost:3000` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6857a3d75c788330bd9f82bed7ec54ae